### PR TITLE
fix: handle quoted combined commands like 'pool login'

### DIFF
--- a/gemini_cli_auth_manager.py
+++ b/gemini_cli_auth_manager.py
@@ -1018,8 +1018,14 @@ def main():
         list_status()
         return
     
-    command = sys.argv[1].lower()
-    args = sys.argv[2:]
+    # Handle combined command and sub-command if quoted
+    if " " in sys.argv[1]:
+        parts = sys.argv[1].split()
+        command = parts[0].lower()
+        args = parts[1:] + sys.argv[2:]
+    else:
+        command = sys.argv[1].lower()
+        args = sys.argv[2:]
     
     # Command routing
     if command == "next":


### PR DESCRIPTION
This PR fixes a bug where the script incorrectly treats quoted combined commands (e.g., `python gemini_cli_auth_manager.py 'pool login'`) as account identifiers, leading to a '[Error] No profiles found.' failure when no accounts are yet added.

The fix ensures that if the first argument contains a space, it is correctly split into a command and sub-command.