### PR TITLE
Add Linux and macOS compatibility

### DIFF
--- a/README-CN.md
+++ b/README-CN.md
@@ -1,7 +1,7 @@
 # Gemini CLI 账号管理器
 
 ![Python](https://img.shields.io/badge/python-3.8+-blue.svg)
-![Platform](https://img.shields.io/badge/platform-Windows-yellow.svg)
+![Platform](https://img.shields.io/badge/platform-Windows%20%7C%20Linux%20%7C%20macOS-yellow.svg)
 ![License](https://img.shields.io/badge/license-MIT-green.svg)
 ![Version](https://img.shields.io/badge/version-2.3-brightgreen.svg)
 
@@ -38,6 +38,15 @@ python install.py
 ### 依赖要求
 - Python 3.8+
 - `requests` 库 (`pip install requests`)
+- Gemini CLI 已安装，并可通过 PATH 中的 `gemini` 命令调用
+
+### Linux/macOS 说明
+- 安装器会创建 `~/.gemini/gchange`，并在可行时链接到 `~/.local/bin/gchange`。
+- 如果安装后找不到 `gchange` 命令，请把下面内容加入你的 shell 配置：
+
+```bash
+export PATH="$HOME/.local/bin:$PATH"
+```
 
 ---
 
@@ -52,7 +61,7 @@ python install.py
 | `/change strategy` | 查看或更改轮换策略 |
 | `/change config` | 快速查看自动切换配置 |
 
-### 2. 终端命令 (CMD/PowerShell)
+### 2. 终端命令
 | 命令 | 说明 |
 | :--- | :--- |
 | `gchange` | 列出所有账号及当前状态 |
@@ -71,7 +80,7 @@ python install.py
 | `strategy` | `gemini3.1-series-only` | 可选：`conservative`, `gemini3.1-pro-only`, `gemini3.1-series-only`, `custom` |
 | `threshold` | `10` | 剩余配额低于 10% 时触发切换 |
 | `model_pattern` | `gemini-3.1.*` | 用于匹配监控模型的正则表达式 |
-| `auto_restart` | `false` | 切换后是否自动重启 CLI (仅 Windows) |
+| `auto_restart` | `false` | 切换后是否自动重启 CLI，取决于当前平台能否启动 `gemini` |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Gemini CLI Auth Manager
 
 ![Python](https://img.shields.io/badge/python-3.8+-blue.svg)
-![Platform](https://img.shields.io/badge/platform-Windows-yellow.svg)
+![Platform](https://img.shields.io/badge/platform-Windows%20%7C%20Linux%20%7C%20macOS-yellow.svg)
 ![License](https://img.shields.io/badge/license-MIT-green.svg)
 ![Version](https://img.shields.io/badge/version-2.3-brightgreen.svg)
 
@@ -38,6 +38,15 @@ python install.py
 ### Dependencies
 - Python 3.8+
 - `requests` library (`pip install requests`)
+- Gemini CLI available as `gemini` on your PATH
+
+### Linux/macOS Notes
+- The installer creates `~/.gemini/gchange` and links it as `~/.local/bin/gchange` when possible.
+- If `gchange` is not found after installation, add this to your shell profile:
+
+```bash
+export PATH="$HOME/.local/bin:$PATH"
+```
 
 ---
 
@@ -52,7 +61,7 @@ python install.py
 | `/change strategy` | View or change rotation strategy |
 | `/change config` | Quick view of auto-switch configuration |
 
-### 2. Terminal Commands (CMD/PowerShell)
+### 2. Terminal Commands
 | Command | Description |
 | :--- | :--- |
 | `gchange` | List all accounts and status |
@@ -71,7 +80,7 @@ Settings are stored in `~/.gemini/auth_config.json`.
 | `strategy` | `gemini3.1-series-only` | `conservative`, `gemini3.1-pro-only`, `gemini3.1-series-only`, `custom` |
 | `threshold` | `10` | Switch account when remaining quota < 10% |
 | `model_pattern` | `gemini-3.1.*` | Regex pattern for model monitoring |
-| `auto_restart` | `false` | Automatically restart CLI after a switch (Windows only) |
+| `auto_restart` | `false` | Automatically restart CLI after a switch when the current platform can launch `gemini` |
 
 ---
 

--- a/gemini_cli_auth_manager.py
+++ b/gemini_cli_auth_manager.py
@@ -570,7 +570,7 @@ def handle_config(args):
         return
     
     key = args[0].lower()
-    valid_keys = ["enabled", "strategy", "model_pattern", "threshold", "max_retries", "notify_on_switch", "cache_minutes", "models_to_check"]
+    valid_keys = ["enabled", "strategy", "model_pattern", "threshold", "max_retries", "notify_on_switch", "auto_restart", "cache_minutes", "models_to_check"]
     
     if key not in valid_keys:
         print(f"{UI.RED}[Error] Invalid config key: {key}{UI.RESET}")
@@ -585,7 +585,7 @@ def handle_config(args):
     value = args[1]
     
     # Type conversion
-    if key in ["enabled", "notify_on_switch"]:
+    if key in ["enabled", "notify_on_switch", "auto_restart"]:
         value = value.lower() in ["true", "1", "yes", "on"]
     elif key in ["threshold", "max_retries", "cache_minutes"]:
         try:

--- a/install.py
+++ b/install.py
@@ -5,6 +5,7 @@ Installs account manager with optional auto-switch hook.
 """
 import json
 import os
+import shlex
 import shutil
 import subprocess
 import sys
@@ -88,6 +89,56 @@ def add_to_path(target_dir):
         print(f"Please manually add this folder to your PATH: {target_str}")
 
 
+def command_string(args):
+    """Return a shell command string for Gemini hook configuration."""
+    args = [str(arg) for arg in args]
+    if sys.platform == "win32":
+        return subprocess.list2cmdline(args)
+    return shlex.join(args)
+
+
+def toml_string(value):
+    """Encode a string as a TOML basic string."""
+    return json.dumps(value, ensure_ascii=False)
+
+
+def create_unix_launcher(gemini_dir, target_script):
+    """Create a Unix launcher and expose it from ~/.local/bin when possible."""
+    launcher = gemini_dir / "gchange"
+    launcher_content = (
+        "#!/bin/sh\n"
+        f"exec {shlex.quote(sys.executable)} {shlex.quote(str(target_script))} \"$@\"\n"
+    )
+
+    with open(launcher, 'w', encoding='utf-8', newline='\n') as f:
+        f.write(launcher_content)
+    launcher.chmod(0o755)
+    print(f"[OK] Unix launcher created: {launcher}")
+
+    user_bin = Path.home() / ".local" / "bin"
+    try:
+        user_bin.mkdir(parents=True, exist_ok=True)
+        bin_launcher = user_bin / "gchange"
+
+        if bin_launcher.exists() or bin_launcher.is_symlink():
+            if bin_launcher.is_symlink() and bin_launcher.resolve() == launcher:
+                print(f"[Skip] PATH launcher already configured: {bin_launcher}")
+            else:
+                print(f"[Warning] PATH launcher already exists: {bin_launcher}")
+                print(f"          Use this command manually if needed: {launcher}")
+        else:
+            bin_launcher.symlink_to(launcher)
+            print(f"[OK] PATH launcher linked: {bin_launcher}")
+
+        path_entries = os.environ.get("PATH", "").split(os.pathsep)
+        if str(user_bin) not in path_entries:
+            print(f"[Info] Add this to your shell profile if 'gchange' is not found:")
+            print(f"       export PATH=\"$HOME/.local/bin:$PATH\"")
+    except OSError as e:
+        print(f"[Warning] Could not configure ~/.local/bin/gchange: {e}")
+        print(f"          Run directly with: {launcher}")
+
+
 def update_settings_json(gemini_dir, after_agent_hook, before_agent_hook=None):
     """Update or create settings.json with hook configurations (official format)."""
     settings_file = gemini_dir / "settings.json"
@@ -109,7 +160,7 @@ def update_settings_json(gemini_dir, after_agent_hook, before_agent_hook=None):
     after_hook_def = {
         "name": "quota-auto-switch",
         "type": "command",
-        "command": f'python {after_agent_hook.as_posix()}',
+        "command": command_string([sys.executable, after_agent_hook]),
         "timeout": 10000,
         "description": "Auto-switch account when quota exhausted"
     }
@@ -134,7 +185,7 @@ def update_settings_json(gemini_dir, after_agent_hook, before_agent_hook=None):
         before_hook_def = {
             "name": "quota-pre-check",
             "type": "command",
-            "command": f'python {before_agent_hook.as_posix()}',
+            "command": command_string([sys.executable, before_agent_hook]),
             "timeout": 10000,
             "description": "Pre-check and switch if last request failed"
         }
@@ -191,6 +242,7 @@ def install():
     target_pre_check = hooks_dir / "quota_pre_check.py"
     target_config = gemini_dir / "auth_config.json"
     target_bat = gemini_dir / "gchange.bat"
+    target_launcher = gemini_dir / "gchange"
     target_toml = commands_dir / "change.toml"
 
     print(f"\nTarget Directory: {gemini_dir}")
@@ -208,19 +260,29 @@ def install():
         print(f"[Error] Source file not found: {core_script}")
         return
 
-    # 5. Create Batch Launcher
-    bat_content = '@echo off\r\npython "%USERPROFILE%\\.gemini\\gemini_cli_auth_manager.py" %*'
-    try:
-        with open(target_bat, 'w', encoding='utf-8') as f:
-            f.write(bat_content)
-        print(f"[OK] Batch launcher created: {target_bat.name}")
-    except Exception as e:
-        print(f"[Error] Creating batch file: {e}")
+    # 5. Create Platform Launcher
+    if sys.platform == "win32":
+        bat_content = (
+            '@echo off\r\n'
+            f'{subprocess.list2cmdline([sys.executable, str(target_script)])} %*'
+        )
+        try:
+            with open(target_bat, 'w', encoding='utf-8') as f:
+                f.write(bat_content)
+            print(f"[OK] Batch launcher created: {target_bat.name}")
+        except Exception as e:
+            print(f"[Error] Creating batch file: {e}")
+    else:
+        try:
+            create_unix_launcher(gemini_dir, target_script)
+        except Exception as e:
+            print(f"[Error] Creating Unix launcher {target_launcher}: {e}")
 
     # 6. Create TOML Command
+    prompt_command = command_string([sys.executable, target_script]) + " {{args}}"
     toml_content = (
-        f'description = "{texts["desc"]}"\n'
-        f'prompt = "!{{python \\"{target_script.as_posix()}\\" {{{{args}}}}}}"\n'
+        f'description = {toml_string(texts["desc"])}\n'
+        f'prompt = {toml_string(f"!{{{prompt_command}}}")}\n'
     )
     try:
         with open(target_toml, 'w', encoding='utf-8') as f:

--- a/quota_api_client.py
+++ b/quota_api_client.py
@@ -5,6 +5,7 @@ Gemini CLI 配额查询 API 客户端
 """
 import json
 import os
+import platform
 import sys
 from pathlib import Path
 from datetime import datetime
@@ -20,6 +21,25 @@ CODE_ASSIST_API_VERSION = "v1internal"
 
 GEMINI_DIR = Path(os.path.expanduser("~/.gemini"))
 OAUTH_CREDS_FILE = GEMINI_DIR / "oauth_creds.json"
+
+
+def code_assist_platform():
+    """Return the Gemini CLI platform metadata for the current OS/CPU."""
+    machine = platform.machine().lower()
+    if machine in ("x86_64", "amd64"):
+        arch = "AMD64"
+    elif machine in ("arm64", "aarch64"):
+        arch = "ARM64"
+    else:
+        return "PLATFORM_UNSPECIFIED"
+
+    if sys.platform == "win32":
+        return "WINDOWS_AMD64" if arch == "AMD64" else "PLATFORM_UNSPECIFIED"
+    if sys.platform == "darwin":
+        return f"DARWIN_{arch}"
+    if sys.platform.startswith("linux"):
+        return f"LINUX_{arch}"
+    return "PLATFORM_UNSPECIFIED"
 
 
 def load_oauth_token():
@@ -55,7 +75,7 @@ def call_load_code_assist(access_token):
     payload = {
         "metadata": {
             "ideType": "GEMINI_CLI",
-            "platform": "WINDOWS_AMD64",
+            "platform": code_assist_platform(),
             "pluginType": "GEMINI",
         }
     }

--- a/quota_auto_switch.py
+++ b/quota_auto_switch.py
@@ -188,10 +188,15 @@ def should_switch_by_strategy(config, model_usage=None):
 
 
 def switch_to_next():
-    """Call gchange next to switch account."""
+    """Call the installed manager directly to switch accounts."""
+    manager_script = GEMINI_DIR / "gemini_cli_auth_manager.py"
+    if not manager_script.exists():
+        log(f"[Auth Manager] Manager script not found: {manager_script}")
+        return None
+
     try:
         result = subprocess.run(
-            ["python", str(GEMINI_DIR / "gemini_cli_auth_manager.py"), "next"],
+            [sys.executable, str(manager_script), "next"],
             capture_output=True,
             text=True,
             timeout=10
@@ -342,4 +347,3 @@ def main():
 
 if __name__ == "__main__":
     main()
-

--- a/quota_pre_check.py
+++ b/quota_pre_check.py
@@ -18,6 +18,7 @@ import os
 import sys
 import subprocess
 import re
+import platform
 from pathlib import Path
 from datetime import datetime, timedelta
 
@@ -29,6 +30,7 @@ GEMINI_DIR = Path(os.path.expanduser("~/.gemini"))
 OAUTH_CREDS_FILE = GEMINI_DIR / "oauth_creds.json"
 AUTH_CONFIG_FILE = GEMINI_DIR / "auth_config.json"
 QUOTA_CACHE_FILE = GEMINI_DIR / "quota_cache.json"
+MANAGER_SCRIPT = GEMINI_DIR / "gemini_cli_auth_manager.py"
 
 # Default configuration
 DEFAULT_THRESHOLD = 10 # 10% remaining triggers switch (integer percentage)
@@ -38,21 +40,50 @@ DEFAULT_STRATEGY = "gemini3.1-series-only"
 DEFAULT_PATTERN = "gemini-3.1.*"
 
 
+def normalize_threshold(value):
+    """Accept config thresholds as either percent integers or fractions."""
+    try:
+        value = float(value)
+    except (TypeError, ValueError):
+        value = DEFAULT_THRESHOLD
+    return value / 100 if value > 1 else value
+
+
 def log(message, level="INFO"):
     """Write log message to stderr (visible in Gemini CLI debug)."""
     timestamp = datetime.now().strftime("%H:%M:%S")
     print(f"[{timestamp}] [quota-pre-check] [{level}] {message}", file=sys.stderr)
 
 
+def code_assist_platform():
+    """Return the Gemini CLI platform metadata for the current OS/CPU."""
+    machine = platform.machine().lower()
+    if machine in ("x86_64", "amd64"):
+        arch = "AMD64"
+    elif machine in ("arm64", "aarch64"):
+        arch = "ARM64"
+    else:
+        return "PLATFORM_UNSPECIFIED"
+
+    if sys.platform == "win32":
+        return "WINDOWS_AMD64" if arch == "AMD64" else "PLATFORM_UNSPECIFIED"
+    if sys.platform == "darwin":
+        return f"DARWIN_{arch}"
+    if sys.platform.startswith("linux"):
+        return f"LINUX_{arch}"
+    return "PLATFORM_UNSPECIFIED"
+
+
 def load_config():
     """Load configuration from auth_config.json."""
     config = {
-        "threshold": DEFAULT_THRESHOLD,
+        "threshold": DEFAULT_THRESHOLD / 100,
         "models_to_check": DEFAULT_MODELS_TO_CHECK,
         "enabled": True,
         "cache_minutes": DEFAULT_CACHE_MINUTES,
         "strategy": DEFAULT_STRATEGY,
         "model_pattern": DEFAULT_PATTERN,
+        "custom_model_pattern": "",
     }
     
     if AUTH_CONFIG_FILE.exists():
@@ -60,12 +91,13 @@ def load_config():
             with open(AUTH_CONFIG_FILE, 'r', encoding='utf-8') as f:
                 data = json.load(f)
                 auto_switch = data.get("auto_switch", {})
-                config["threshold"] = auto_switch.get("threshold", DEFAULT_THRESHOLD * 100) / 100
+                config["threshold"] = normalize_threshold(auto_switch.get("threshold", DEFAULT_THRESHOLD))
                 config["enabled"] = auto_switch.get("enabled", True)
                 config["models_to_check"] = auto_switch.get("models_to_check", DEFAULT_MODELS_TO_CHECK)
                 config["cache_minutes"] = auto_switch.get("cache_minutes", DEFAULT_CACHE_MINUTES)
                 config["strategy"] = auto_switch.get("strategy", DEFAULT_STRATEGY)
                 config["model_pattern"] = auto_switch.get("model_pattern", DEFAULT_PATTERN) # pattern for gemini3-first
+                config["custom_model_pattern"] = auto_switch.get("custom_model_pattern", "")
         except:
             pass
     
@@ -147,7 +179,7 @@ def get_project_id(access_token):
     payload = {
         "metadata": {
             "ideType": "GEMINI_CLI",
-            "platform": "WINDOWS_AMD64",
+            "platform": code_assist_platform(),
             "pluginType": "GEMINI",
         }
     }
@@ -275,10 +307,14 @@ def check_quota(config, session_id):
 
 
 def switch_account():
-    """Call gchange next to switch account."""
+    """Call the installed manager directly to switch accounts."""
+    if not MANAGER_SCRIPT.exists():
+        log(f"Manager script not found: {MANAGER_SCRIPT}", "ERROR")
+        return False
+
     try:
         result = subprocess.run(
-            ["gchange", "next"],
+            [sys.executable, str(MANAGER_SCRIPT), "next"],
             capture_output=True,
             text=True,
             timeout=10
@@ -294,7 +330,7 @@ def switch_account():
             log(f"Account switch failed: {result.stderr}", "ERROR")
             return False
     except Exception as e:
-        log(f"Failed to call gchange: {e}", "ERROR")
+        log(f"Failed to call auth manager: {e}", "ERROR")
         return False
 
 

--- a/restart_helper.py
+++ b/restart_helper.py
@@ -8,6 +8,7 @@ import sys
 import time
 import subprocess
 import argparse
+import shutil
 
 def restart_gemini(pid, delay):
     """
@@ -45,8 +46,11 @@ def restart_gemini(pid, delay):
                 close_fds=True
             )
         else:
-            # Linux/Mac (placeholder, mostly for Windows user)
-            subprocess.Popen(["gemini"], start_new_session=True)
+            gemini_cmd = shutil.which("gemini")
+            if not gemini_cmd:
+                print("[Restart Helper] Gemini CLI not found on PATH; restart skipped.", file=sys.stderr)
+                return
+            subprocess.Popen([gemini_cmd], start_new_session=True, close_fds=True)
             
     except Exception as e:
         print(f"[Restart Helper] Failed to start new instance: {e}", file=sys.stderr)


### PR DESCRIPTION
## Summary
- add Unix launcher installation for Linux/macOS while preserving Windows batch launcher behavior
- use the current Python executable for Gemini hooks and slash command generation
- align Code Assist platform metadata with Gemini CLI values and avoid PATH-dependent hook switching
- update docs for cross-platform installation and auto-restart behavior

## Tests
- python3 -m py_compile install.py gemini_cli_auth_manager.py quota_auto_switch.py quota_pre_check.py quota_api_client.py restart_helper.py
- git diff --check
- python3 -c "import quota_pre_check, quota_api_client; print(quota_pre_check.code_assist_platform()); print(quota_api_client.code_assist_platform())"